### PR TITLE
Updated to latest version

### DIFF
--- a/include/rbx/offsets.hpp
+++ b/include/rbx/offsets.hpp
@@ -18,12 +18,12 @@ namespace rrlog::rbx
         const std::uintptr_t _hyperion_base;
 
         // Offsets in the Roblox client
-        static constexpr std::uintptr_t _yr_scanner_ctx = 0x6725CE8;
-        static constexpr std::uintptr_t _scanner_match_memory = 0x29FEAE0;
-        static constexpr std::uintptr_t _scanner_get_ruleset_string = 0x29FF220;
+        static constexpr std::uintptr_t _yr_scanner_ctx = 0x675A4B8;
+        static constexpr std::uintptr_t _scanner_match_memory = 0x2862BE0;
+        static constexpr std::uintptr_t _scanner_get_ruleset_string = 0x2863320;
 
         // Offsets in Hyperion
-        static constexpr std::uintptr_t _global_scan_statistics = 0x2d7530;
+        static constexpr std::uintptr_t _global_scan_statistics = 0x2D64BC;
 
        public:
         /// <summary>

--- a/include/rbx/scanner.hpp
+++ b/include/rbx/scanner.hpp
@@ -6,17 +6,36 @@
 
 namespace rrlog::rbx
 {
+
+    template< typename T >
+    struct persistent_allocator : std::allocator< T >
+    {
+        template< typename U >
+        struct rebind
+        {
+            using other = persistent_allocator< U >;
+        };
+
+        void deallocate( T* p, std::size_t n )
+        {
+            /**
+             * Deallocating would cause a crash when freeing our match result (likely due to being double freed),
+             * we might be leaking memory but I don't think it's that important than making sure we don't crash.
+             */
+        }
+    };
+
     /// <summary>
     /// A match result returned by `match_memory`.
     /// </summary>
     struct match_result_t
     {
         std::uint32_t status;
-        std::vector< std::uint64_t > ruleset_ids;
+        std::vector< std::uint64_t, persistent_allocator< std::uint64_t > > ruleset_ids;
     };
 
     /// <summary>
-    /// The memory scan statistics stored in Hyperion. 
+    /// The memory scan statistics stored in Hyperion.
     /// </summary>
     struct memory_scan_statistics_t
     {


### PR DESCRIPTION
Updated offsets to latest version `version-9bf2d7ce6a0345d5` and fixed crash by (most likely) the std::vector in match result being freed twice (by roblox and then ourself)